### PR TITLE
Added functionality to specify how often to output model and plots during a training loop

### DIFF
--- a/maestroflame/maestroflame/train.py
+++ b/maestroflame/maestroflame/train.py
@@ -109,10 +109,10 @@ class NuclearReactionML:
 
 
                 #LOADING DATA----------------------------------------------------------
-                # plotfiles = glob(data_path + plotfile_prefix)
-                # plotfiles = sorted(plotfiles)
-                # plotfiles = plotfiles[:-2] #cut after divuiter and initproj
-                # plotfiles = [plotfiles[-1]] + plotfiles[:-1] #move initdata to front.
+                plotfiles = glob(data_path + plotfile_prefix)
+                plotfiles = sorted(plotfiles)
+                plotfiles = plotfiles[:-2] #cut after divuiter and initproj
+                plotfiles = [plotfiles[-1]] + plotfiles[:-1] #move initdata to front.
                 #make_movie(plotfiles, movie_name='enuc.mp4', var='enuc')
 
                 react_data = ReactDataset(data_path, input_prefix, output_prefix, plotfile_prefix, DEBUG_MODE=DEBUG_MODE)


### PR DESCRIPTION
When calling train on the two main classes, just pass `save_every_N` as a keyword and set this to any number.

It's defaulted at infinity meaning it will never save.

It creates a folder called `intermediate_output` which has subfolders for each `save_every_N` epochs that contain the partially trained model and all the usual plots. 